### PR TITLE
Hide additional nitro promotion banner - Update Useful.css

### DIFF
--- a/Useful.css
+++ b/Useful.css
@@ -30,6 +30,11 @@ button[class*='emojiItemDisabled'] {
     display: none;
 }
 
+/* Hides the additional nitro promotion banner/widget that appears when scrolling in the emoji picker */
+.upsellContainer_ad7baa {
+    display: none;
+}
+
 /* Hides the divider between "Frequently Used" and server emojis */
 .nitroTopDividerContainer_e8f337 {
     display: none;


### PR DESCRIPTION
Hides the additional nitro promotion popup/banner that appears only once you have scrolled in the emoji picker.

**Before**
![image](https://github.com/user-attachments/assets/f6292d43-ce38-4106-b564-6ab4d127a627)

**After**
![image](https://github.com/user-attachments/assets/59810a33-74c4-413c-a106-c67108535cb7)
