### PR TITLE
Update DiscordFreeEmojis.plugin.js

### DIFF
--- a/DiscordFreeEmojis.plugin.js
+++ b/DiscordFreeEmojis.plugin.js
@@ -186,7 +186,7 @@ var FreeEmojis = (() => {
 
             //Make emoji invisible via markdown link and invisible character
             if (pluginSettings.invisibleEmojiLink.value)
-                replacement = `[󠄀](${emojiUrl}) `;
+                replacement = `[󠄀](${emojiUrl})`;
             else
                 replacement = emojiUrl;
 


### PR DESCRIPTION
On Line 189 there is a space in between the right parenthesis and the grave accent, leading to a blank space that is unnoticeable unless you spoiler the emoji, then it will show a blank letter above it that is also spoilered
(animated emojis are still affected for some reason, idk i have zero programming skills)
<img width="113" height="159" alt="Screenshot 2025-12-27 095403" src="https://github.com/user-attachments/assets/2df2fe38-376b-4b59-bc39-dfb4aa4a7ef3" />
